### PR TITLE
migrate topic descriptions from google doc

### DIFF
--- a/Topic 10 An IPFS-Blockchain Interface/readme.md
+++ b/Topic 10 An IPFS-Blockchain Interface/readme.md
@@ -1,11 +1,28 @@
-#
+
+# A LifeBlock traceability and provenance service for data from external sources
+
+More info:
+https://drive.google.com/file/d/1Ou7Jph3Z_93PNzi6VBeXpptABkQAqm4R/view?usp=sharing
 
 ## Partners
+- Lifewatch ERIC (lead) @Francisco Sanchez
+- GBIF
+- Plazi
+- CETAF
+- Species 2000
 
 ## Infrastructures to be used 
 
 ## Rationale
 
+LifeWatch ERIC is currently developing Lifeblock for ecosystem data management. LifeBlock technology will allow data management from multiple data sources with traceability characteristics, provenance and application of FAIR principles. The management of these data at the time they have been obtained for their application to publications, algorithm management, VREs or other types of research projects, often has the disadvantage of the state of the data at the time they were acquired and its later evolution. Many times the inevitable updating of data sources makes it very complex to justify the results of many of the studies carried out, given that the results may vary as a result of data update in the source. LifeBlock infrastructure has mechanisms based on blockchain and IPFS for better management and future storage of data, as well as the incorporation of a tokenization system, which allows the incorporation of new data sources and the management of their traceability and provenance using the general principles of DLTs architectures regarding the maintenance and preservation of information. The objective of LifeWatch ERIC for this hackathon would be to be able to verify the operation of this system against data sources such as GBIF, CETAF, Plazi, etc., which are present in the BiCIKL project and in this way to be able to provide to these data sources and to the community in general a tool that can be used to carry out the traceability and provenance of the data that may be used in any investigation.
+
 ## Methodology
+Our objective will be to launch LifeBlock using the APIs of data sources such as GBIF, CETAF, Plazi, etc., and determine the operation of the system and the usefulness that the methodology used by LifeBlock may have in the future for these data sources, trying to understand the necessary variations or the particularities of each of the information sources when managing and processing their data by LifeBlock.
 
 ## Outputs
+The expected outputs on our part would be:
+
+- Refine the LifeBlock data provenance and traceability system by better understanding the characteristics of each of the data sources.
+- Provide a tool to the community and to these databases in particular to carry out the traceability and provenance of the data used in the investigations.
+- Demonstrate the usefulness of distributed technologies for use in ecosystem data management.

--- a/Topic 10 An IPFS-Blockchain Interface/readme.md
+++ b/Topic 10 An IPFS-Blockchain Interface/readme.md
@@ -1,0 +1,11 @@
+#
+
+## Partners
+
+## Infrastructures to be used 
+
+## Rationale
+
+## Methodology
+
+## Outputs

--- a/Topic 2 How good are Triple IDs in ENA/readme.md
+++ b/Topic 2 How good are Triple IDs in ENA/readme.md
@@ -1,11 +1,21 @@
-#
+# How good are Triple IDs in ENA?
 
 ## Partners
+- BGBM (lead) @Jörg Holetschek
+- ENA
+- [Global Biodiversity Information Facility](https://www.gbif.org/) (GBIF)
 
 ## Infrastructures to be used 
-
+- ENA
+- GBIF
+  
 ## Rationale
+Large sets of records in the **European Nucleotide Archive (ENA)** reference specimens (e.g., as specimen_voucher, bio_material, or culture_collection) through the use of GBIF triple IDs. However, it is unclear whether these links correctly and reliably reference specimen records in **GBIF**. During the hackathon, we want to investigate these links in more detail and develop automated methods for their validation and correction.
 
 ## Methodology
+We will first query all triple IDs present in the different object categories in ENA using the ENA API. We will then run these against the GBIF API and determine the number of exact matches as well as the number of approximate matches. For the approximate hits, we first need to define an appropriate similarity measure.
+For the similar hits and triple IDs that have multiple potential hits, we will use e.g. Openrefine to compare metadata from GBIF, metadata from the primary sources (e.g. via CETAF IDs) with the specimen data stored in ENA and propose a procedure for automatically correcting/annotating triple IDs in ENA.
 
 ## Outputs
+- a better understanding of the quality of Triple ID references in ENA.
+- methods for validation of triple IDs in ENA and auto-correction/annotation.

--- a/Topic 2 How good are Triple IDs in ENA/readme.md
+++ b/Topic 2 How good are Triple IDs in ENA/readme.md
@@ -1,0 +1,11 @@
+#
+
+## Partners
+
+## Infrastructures to be used 
+
+## Rationale
+
+## Methodology
+
+## Outputs

--- a/Topic 3 Enhance the GBIF clustering algorithms/readme.md
+++ b/Topic 3 Enhance the GBIF clustering algorithms/readme.md
@@ -1,11 +1,20 @@
-#
+# Enhance the GBIF clustering algorithms
 
 ## Partners
+- GBIF (lead) @Tim Robertson
+- TDWG
+- Naturalis
 
 ## Infrastructures to be used 
-
+- GBIF 
 ## Rationale
+Metadata about digitised specimens, sequences and material citations and observations are made available through a consistent data model in GBIF.org. The features within the model are structured using the Darwin Core vocabularies. GBIF now runs a basic clustering algorithm to identify linkages across these entries, which currently covers approximately 100M records, including 6M specimens (see https://www.gbif.org/news/4U1dz8LygQvqIywiRIRpAU). There is much that can be done to improve this current algorithm to identify more linkages, such as 1) handling variety in how people (names and IDs) are represented, 2) better parsing of botanical field numbers, 3) exploring different ML approaches (such as LinkedIn SCANNS https://github.com/LinkedInAttic/scanns) and 4) develop an approach to testing to quantify if improvements are being made over time. GBIF develops openly and it is expected that further collaborative work could continue beyond the hackathon. Improvements made to the algorithm will be put into production and run as part of ongoing operations at GBIF.
 
 ## Methodology
 
 ## Outputs
+- A distributed team of collaborators contributing to the production workflows of GBIF is seen as the main output (i.e. team building)
+- Knowledge sharing of GBIF operations; namely the big data processing environments used by GBIF and file formats (Spark, Hive, HBse, Parquet etc)
+- More linkages between objects through the GBIF APIs (material citations, specimens, sequences)
+- A more robust mechanism to monitor ongoing improvements to the GBIF clustering
+

--- a/Topic 3 Enhance the GBIF clustering algorithms/readme.md
+++ b/Topic 3 Enhance the GBIF clustering algorithms/readme.md
@@ -1,0 +1,11 @@
+#
+
+## Partners
+
+## Infrastructures to be used 
+
+## Rationale
+
+## Methodology
+
+## Outputs

--- a/Topic 4 Assigning latin scientific names to OTUs based on sequence clusters/readme.md
+++ b/Topic 4 Assigning latin scientific names to OTUs based on sequence clusters/readme.md
@@ -1,11 +1,22 @@
-#
+
+# Assigning latin scientific names to OTUs based on sequence clusters
 
 ## Partners
-
+- GBIF (lead) @Thomas Jeppesen
+- UNITE/PlutoF
+- COL
 ## Infrastructures to be used 
-
+- GBIF
+- COL
 ## Rationale
+Curated sequence databases are important tools in modern taxonomy. They are used to identify sequences at the operational taxonomic unit (OTU) level. OTUs are usually represented by some stable identifier, such as the Species Hypothesis (SH) in **UNITE** or the Barcode Index Number (BIN) in the **Barcode of Life Data System (BOLD)**. In principle, these identifiers represent Species/Taxon concepts. In order to answer the question "What species does this sequence represent?" a linkage from an OTU identifier to a latin scientific name is needed. The taxon name for an OTU in the reference database has to somehow be derived from the taxonomic annotation of the sequences constituting the OTU. Currently, BOLD does not provide a single consensus taxon name for each BIN. In order to apply a taxon name, users therefore have to inspect all taxonomic annotations within the BIN and pick one. When blasting a single or a few sequences, this approach may suffice. However, in a taxonomic classification pipeline for many sequences, e.g. metabarcoding, this approach is impossible. Similarly, In order to place BINs or SHs into classic taxonomies such as the **GBIF** backbone taxonomy or the **Catalogue of Life** all bins must be unambiguously linked to a (parent) taxon.
+
+Therefore an algorithm for selecting a taxon name for an OTU is important for linking molecular data to the world of museum specimens, treatments, etc.
 
 ## Methodology
+Explore the algorithms for taxonomic assignment currently used by UNITE/PlutoF and the International Barcode of Life project (iBOL) Barcode Index Numbers (BINs) dataset in GBIF https://www.gbif.org/dataset/4cec8fef-f129-4966-89b7-4f8439aba058 and discuss shortcomings and advantages.
 
+Explore improvements based on the underlying data. See https://dx.doi.org/10.3390%2Fmicroorganisms8121910
 ## Outputs
+New algorithm, or improvements for existing algorithms for assigning latin scientific names to sequence based OTUs.
+

--- a/Topic 4 Assigning latin scientific names to OTUs based on sequence clusters/readme.md
+++ b/Topic 4 Assigning latin scientific names to OTUs based on sequence clusters/readme.md
@@ -1,0 +1,11 @@
+#
+
+## Partners
+
+## Infrastructures to be used 
+
+## Rationale
+
+## Methodology
+
+## Outputs

--- a/Topic 5 Registering biodiversity-related vocabulary as Wikidata lexemes and link their senses to Wikidata items/readme.md
+++ b/Topic 5 Registering biodiversity-related vocabulary as Wikidata lexemes and link their senses to Wikidata items/readme.md
@@ -1,11 +1,21 @@
-#
+# Registering biodiversity-related vocabulary as Wikidata lexemes and link their senses to Wikidata items
 
 ## Partners
+- Pensoft (lead)
+- Wikidata
+- Plazi
+- COL
 
 ## Infrastructures to be used 
-
+- Wikidata
+- COL
+  
 ## Rationale
+Content mining involves a combination of methods that take into account knowledge about (i) the documents being mined, (ii) the languages used therein, (iii) the documents’ content and (iv) specific use cases at hand. While special workflows exist for mining biodiversity information (e.g. Plazi), it would be desirable to have such workflows more readily available to and reusable by a broader community and to invite community members to help curate the underlying information. Integration of such workflows with Wikidata would be a good step forward in this direction.
 
 ## Methodology
+Wikidata is a FAIR and open semantic database that is community-curated following the Wikipedia approach that “anyone can edit it”. Besides information about concepts and their relationship between each other and the wider world (known as **items** and **properties** in Wikidata parlance, largely equivalent to the **subjects** and **predicates** in semantic web lingo), Wikidata has also begun to [store structured information about languages and their components](https://www.wikidata.org/wiki/Wikidata:Lexicographical_data), which it calls **lexemes**. The idea of this hackathon project would be to (i) pick a set of documents - possibly some that other groups at the hackathon are analyzing or producing, such as taxonomic publications or taxon treatments - or similar resources in one or more target languages and (ii) use natural language processing to (iia) extract biodiversity-related words and phrases, (iib) upload such vocabulary as lexemes to Wikidata, (iic) curate those lexeme entries by adding information about their grammar, **senses** and usages, and (iii) make provisions to scale this up.
 
 ## Outputs
+The minimal outcome of this hackathon project would be the documentation of a workflow - for at least one BiCIKL infrastructure - that covers in detail the steps listed under “ii” in the methodology section above, ideally based on use cases (as per “i”) for which automation (as per “iii”) is within reach. In the long run, doing this systematically for one or more of the BiCIKL research infrastructures will help disambiguate ambiguous terms better and recognize biodiversity-related entities with higher precision across a growing range of linguistic and thematic contexts and document types. Such improved workflows can help improve the information in Wikidata, thereby providing the basis for a positive data quality feedback loop between content mining and Wikidata-based curation of linguistic and subject-matter contexts for such content.
+

--- a/Topic 5 Registering biodiversity-related vocabulary as Wikidata lexemes and link their senses to Wikidata items/readme.md
+++ b/Topic 5 Registering biodiversity-related vocabulary as Wikidata lexemes and link their senses to Wikidata items/readme.md
@@ -1,0 +1,11 @@
+#
+
+## Partners
+
+## Infrastructures to be used 
+
+## Rationale
+
+## Methodology
+
+## Outputs

--- a/Topic 6 FAIR Digital Object design from multiple sources/readme.md
+++ b/Topic 6 FAIR Digital Object design from multiple sources/readme.md
@@ -1,11 +1,40 @@
-#
+# FAIR Digital Object design for data from multiple sources 
 
 ## Partners
+- Naturalis (lead) @Sharif Islam @Wouter Addink
+- TDWG
+- GBIF
+- ENA
+- OpenBiodiv
+- DiSSCo
 
 ## Infrastructures to be used 
 
 ## Rationale
 
+FAIR Digital Objects (FDO) are actionable Digital Objects with persistent identifiers and properties. It provides a mechanism for abstract data constructs that can span multiple domains and data sources. It can also create abstractions for different segmentations within a data intensive workflow with identifiers and data type validation. 
+
+These and other properties make FDO an ideal candidate to explore and link different biodiversity data classes such as taxon, specimens, sequences. However, conceptual knowledge encoded in domain ontologies and vocabularies are known obstacles for data reference, linking, and merging. FDO can work as an anchor for creating an interoperable digital object in this case.  
+
+The goal of this task is to explore ideas and methods to create FAIR Digital Objects that can provide a schema to either connect and link or combine the disparate digital objects within a coherent structure. 
+
+### Example
+[GBIF occurrence data](https://api.gbif.org/v1/occurrence/2443791360) for *Isabellaria isabellina isabellina* and **Naturalis Bioportal** catalog records (for example, [RMNH.MOL.47311](https://api.biodiversitydata.nl/v2/specimen/findByUnitID/RMNH.MOL.47311) and [RMNH.MOL.47312](https://api.biodiversitydata.nl/v2/specimen/findByUnitID/RMNH.MOL.47312)) and related [ENA record](https://www.ebi.ac.uk/ena/browser/api/embl/AY382076.1) are about the preserved specimens for the same organism. There are also objects describing the scientific name ([openbiodiv](http://openbiodiv.net/F1DD0CF0-217D-422B-BAA4-58901976D7B4-4570425-scName) and [Catalogue of Life](https://data.catalogueoflife.org/dataset/2296/taxon/7GXFW)) using different data structures. These objects all have slightly different data elements that introduce semantic heterogeneity and structural differences. For example, the Naturalis Bioportal primarily uses ABCD terms (such as [RecordBasis](https://terms.tdwg.org/wiki/abcd2:RecordBasis)) and GBIF uses Darwin Core ([basisOfRecord](https://dwc.tdwg.org/terms/#dwc:basisOfRecord)).  Even though there are mapped terms ([CODATA / TDWG Task Group on Access to Biological Collection Data](https://www.bgbm.org/TDWG/CODATA/Schema/Mappings/DwCAndExtensions.htm)), linking, merging different structures is not that trivial. Furthermore, adding sequence and taxonomic data to the mix complicates the matter further. 
+
+
+
 ## Methodology
+Propose different data elements from at least two different data sources that are describing similar or related objects. They could be linked via identifiers or other entities or not. By looking at the content of these objects (possibly programmatically) a schema label will be generated. As a lot of data linking requires common information or identifiers, unique schema labels are needed. Each data source has their own schema label even if they refer to the same concept. In the above example, The Naturalis record has 
+``"recordBasis": "PreservedSpecimen"`` but GBIF has ``"basisOfRecord": “PRESERVED_SPECIMEN"``;  ``"className": "Gastropoda"`` vs ``“class": "Gastropoda"``; 
+``"sourceInstitutionID": "Naturalis Biodiversity Center"`` vs ``"institutionCode": "Naturalis"``; ``"preparationType: air dried"`` vs ``“preparations: air dried"``. 
+
+We will evaluate several approaches to process the mapping of these schemas based on semantic similarity:
+- A simple framework would be to model entities/classes as n-grams and define similarity based on the Levenstein distance
+- If classes are DwC/ABCD classes or could be mapped to those (using the method above), more advanced methods of graph matching for the RDF representation of DwC (https://dwc.tdwg.org/rdf/) and ABCD (v 3.0 https://abcd.biowikifarm.net/wiki/Main_Page) could be applied (e.g. Graph Convolutional Networks).
+- A major step forward for the harmonisation of data schemas will be the integration of DwC/ABCD terms as subclasses of a domain ontology like the Biological Collections Ontology (BCO). Recent efforts in this respect are dwcobo ([BiodiversityOntologies/dwcobo: code for creating in Darwin Core ontology modules to import to BCO](https://github.com/BiodiversityOntologies/dwcobo)) and DiSSCo’s open Digital Specimen (opeDS) ontology ([openDS/ods-ont-intro.md at master · DiSSCo/openDS](https://github.com/DiSSCo/openDS/blob/master/ods-ontology/ods-ont-intro.md)). A full representation in OWL would enable more complex methods of symbolic (e.g. LogMap-based alignment) and combined symbolic/subsymbolic approaches like OPA2Vec (https://github.com/bio-ontology-research-group/machine-learning-with-ontologies). 
+
 
 ## Outputs
+- A framework and recipe to label schema and align terms. 
+- A new FAIR Digital Object schema and corresponding Data Types.
+- A prototype of a Digital Object repository (based on cordra) for the new FAIR DO type.   

--- a/Topic 6 FAIR Digital Object design from multiple sources/readme.md
+++ b/Topic 6 FAIR Digital Object design from multiple sources/readme.md
@@ -1,0 +1,11 @@
+#
+
+## Partners
+
+## Infrastructures to be used 
+
+## Rationale
+
+## Methodology
+
+## Outputs

--- a/Topic 7 Enriching Wikidata with information from OpenBiodiv about taxonomic name usages in context from different literature sources/readme.md
+++ b/Topic 7 Enriching Wikidata with information from OpenBiodiv about taxonomic name usages in context from different literature sources/readme.md
@@ -1,11 +1,25 @@
-#
+# Enriching Wikidata with information from OpenBiodiv about taxonomic name usages in context from different literature sources
 
 ## Partners
-
+- Pensoft (lead) @Mariya Dimitrova
+- OpenBiodiv
+- Wikidata
+- GBIF
+- Plazi
+- Zoobank
 ## Infrastructures to be used 
-
+- Wikidata
+- GBIF
+- OpenBiodiv SPARQL endpoints
+  
 ## Rationale
+Taxonomic literature is a rich source of biodiversity knowledge. The structure of taxonomic journal articles generally follows established rules for formatting of taxonomic treatments (e.g., description of new taxa or re-description of the existing ones), as well as other generic parts such as title, abstract, keywords, introduction, results and so on. These rules, as well as the XML-tagging implemented in the routine publication process at **Pensoft**, have allowed us to create and populate the **OpenBiodiv** knowledge graph with Linked Open Data statements extracted from literature, following the OpenBiodiv-O ontology. One of the key types of information within OpenBiodiv are taxonomic names usages (TNUs): mentionings of taxonomic names within different sections of the journal article. On its own, this information is valuable because it indicates the importance of a given taxonomic name in a specific article. Furthermore, co-mentionings of several taxa together, or of a taxon name and a habitat or environmental term can imply a relatedness between these. The incorporation with other information (geolocation data, ecology data, etc.) can provide additional context to TNUs in literature. Currently, OpenBiodiv has indexed 4 993 677 usages of 2 497 310 taxon names. 
+
+Wikidata is another open source of biodiversity information, which contains not only information about taxonomic names and hierarchy, but also external identifiers (links) about a specific taxon. For example, the Wikidata record for the beetle genus [Elater](https://www.wikidata.org/wiki/Q13033998) has 17 such identifiers to records from databases such as Zoobank, GBIF, iNaturalist, NCBI Taxonomy, Plazi, BOLD Systems, etc. In essence, these links contain information about occurrences, treatments, images and molecular data about specimens. Taxonomic name usages from OpenBiodiv integrated with existing **Wikidata** records can add another piece to the puzzle by adding more literature data.
 
 ## Methodology
+We will perform federation between the Wikidata and OpenBiodiv SPARQL endpoints to match taxonomic names in the two databases. Matching could be performed not only between the names themselves but also between the accompanying **GBIF** taxon identifiers (the GBIF taxonomic backbone is RDF-ized in OpenBiodiv), **Zoobank** identifiers and/or **Plazi** treatment identifiers. We will aggregate information about TNUs within article sections (Title, Abstract, Introduction, Treatment, Materials Examined, Distribution, etc.) and provide it to Wikidata. One of the key questions is how to model this information as Wikidata statements. One approach would be to provide statistical information in one set of statements (number of TNUs per section) as well as article metadata (DOI) in another set of statements to answer the question 'In which specific article is a taxonomic name mentioned?'. In addition, we could add statements about co-mentioning of several taxonomic names together (e.g. in the Treatment section)
 
 ## Outputs
+- Statements in Wikidata about taxonomic name usages in context from different literature sources
+- Established workflow for federation between OpenBiodiv and Wikidata

--- a/Topic 7 Enriching Wikidata with information from OpenBiodiv about taxonomic name usages in context from different literature sources/readme.md
+++ b/Topic 7 Enriching Wikidata with information from OpenBiodiv about taxonomic name usages in context from different literature sources/readme.md
@@ -1,0 +1,11 @@
+#
+
+## Partners
+
+## Infrastructures to be used 
+
+## Rationale
+
+## Methodology
+
+## Outputs

--- a/Topic 8 Linking specimen with material citation and vice versa/readme.md
+++ b/Topic 8 Linking specimen with material citation and vice versa/readme.md
@@ -1,0 +1,11 @@
+#
+
+## Partners
+
+## Infrastructures to be used 
+
+## Rationale
+
+## Methodology
+
+## Outputs

--- a/Topic 8 Linking specimen with material citation and vice versa/readme.md
+++ b/Topic 8 Linking specimen with material citation and vice versa/readme.md
@@ -1,11 +1,30 @@
-#
+# Linking specimen with material citation and vice versa 
 
 ## Partners
+- Plazi (lead) @Donat Agosti
+- SIB 
+- BFH
+- MBG
+- GBIF
+- BGBM - Botanischer Garten Berlin?: Especially Natural History collections that issue persistent identifiers for specimens, and in the better case, have a corpus of publications that already make use of this.
 
 ## Infrastructures to be used 
 
 ## Rationale
 
+Material citations are citations of physical specimens, observations or groups thereof in taxonomic treatments in scholarly publications. Though these are citations, these are based on implicit links. To create a knowledge graph, these links have to be explicit. Similarly, to understand what is known about a specimen, a link needs to be made from the specimen to its material citations and the inclosing treatment and publication. If possible, these links will be complemented by persistent identifiers for treatments, material citations and specimens. 
+
 ## Methodology
+A test corpus of specimen data and treatments and material citations from publications where they are cited will be prepared and their fields matched or based on the Darwin Core vocabulary. This will allow testing the algorithms, to develop an optimal way to find the complements, and get some matching statistics.
+Options will be explored using the data provided by a specimen or material citation, or to find and use specimen codes to link.
+Solutions to annotate the specimens and the material citations with the respective identifiers will be explored.
+
+A curation interface will be described and developed.
+
+A user interface for curation will be designed to get data curators involved to optimize for use.
 
 ## Outputs
+- algorithms that allow finding the respective representations in either database
+- a demonstration system allowing annotating the specimen and material citations with the respective identifiers
+- A test user Interface that facilitates human interactions to curate links created by automation or create links that have not been discovered.
+

--- a/Topic 9 Hidden women in science/readme.md
+++ b/Topic 9 Hidden women in science/readme.md
@@ -1,11 +1,34 @@
-#
+# Hidden women in science
 
 ## Partners
+- MBG (lead) @Maarten Trekels
+- Wikidata
+- Plazi
+- GBIF
+- CETAF
+- Science stories
 
 ## Infrastructures to be used 
-
+- Wikidata
+- Wikipedia
+- sciencestories.io
+- Bionomia
+- BHL
+- GBIF
+  
 ## Rationale
+Due to various sociological and historical reasons, great achievements of women in science often disappear under the radar. In order to make sure that the attribution of these achievements is correctly associated with the scientists. It is essential to make sure that women are equally represented in the infrastructures and that their works are correctly linked to the right person. Especially the large infrastructures have a big responsibility to represent the reality in a correct way.
 
 ## Methodology
-
+Suggestions on how we can proceed with this:
+- adding articles on Wikipedia / **Wikidata** → creating Science Stories (sciencestories.io). Can we add other data in a story? Extent the story?
+- Work on bionomia / disambiguation
+- text mining / computer vision on documents (BHL, treatments…)?
+- clustering on **GBIF** data?
+  
 ## Outputs
+Possible outcomes:
+- defining a workflow
+- adding functionality to a specific tool
+- recommendations
+

--- a/Topic 9 Hidden women in science/readme.md
+++ b/Topic 9 Hidden women in science/readme.md
@@ -1,0 +1,11 @@
+#
+
+## Partners
+
+## Infrastructures to be used 
+
+## Rationale
+
+## Methodology
+
+## Outputs

--- a/readme.md
+++ b/readme.md
@@ -17,3 +17,18 @@ All BiCIKL partners are invited to propose topics which will then be reviewed in
 10. [An IPFS-Blockchain Interface](Topic%2010%20An%20IPFS-Blockchain%20Interface/readme.md)
 
 
+## Topic Overview
+
+|Project number|Project title|Lead|Partners/infrastructures involved|
+|---|---|---|---|
+|1|Finding the lost parents|MBG ([Quentin Groom)](mailto:quentin.groom@plantentuinmeise.be)|SIB, GBIF, COL, Plazi, Wikidata|
+|2|How good are Triple IDs in ENA?|BGBM [(Jörg Holetschek)](mailto:J.Holetschek@bgbm.org)|ENA, GBIF|
+|3|Enhance the GBIF clustering algorithms|GBIF [(Tim Robertson)](mailto:trobertson@gbif.org)||
+|4|Assigning latin scientific names to OTUs based on sequence clusters|GBIF [(Thomas Jeppesen)](mailto:tsjeppesene@gbif.org)|UNITE/PlutoF, COL|
+|5|Registering biodiversity-related vocabulary as Wikidata lexemes and link their senses to Wikidata items|Pensoft [(Daniel Mietchen)](mailto:dm7gn@virginia.edu)|Wikidata, Plazi, COL|
+|6|FAIR Digital Object design from multiple sources|Naturalis ([Sharif Islam](mailto:sharif.islam@naturalis.nl), [Wouter Addink](mailto:wouter.addink@naturalis.nl))|TDWG, GBIF, ENA, OpenBiodiv, DiSSCo|
+|7|Enriching Wikidata with information from OpenBiodiv about taxonomic name usages in context from different literature sources|Pensoft [(Mariya Dimitrova)](mailto:m.dimitrova@pensoft.net)|OpenBiodiv, Wikidata, GBIF, Plazi, Zoobank|
+|8|Linking specimen with material citation and vice versa|Plazi [(Donat Agosti)](mailto:agosti@amnh.org)|SIB, BFH, MBG, GBIF, BGBM|
+|9|Hidden women in science|MBG [(Maarten Trekels)](mailto:maarten.trekels@plantentuinmeise.be)|Wikidata, Plazi, GBIF, CETAF, Science stories|
+|10|An IPFS-Blockchain Interface|LifeWatch ERIC [(Francisco Sanchez)](mailto:franciscom.sanchez@lifewatch.eu)|GBIF, Plazi, CETAF, Species 2000|
+

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ The BiCIKL BioHackathon will take place on September 20-24, 2021 at Meise Botani
 
 All BiCIKL partners are invited to propose topics which will then be reviewed in the week of June 28-July 2 by partners involved in Task 1.2. Please add your ideas for topics with a short description in this document by the end of this week. Please describe clearly which infrastructures would be involved and how the hackathon could contribute in making the infrastructures more interoperable. 
 
-1. [Lost Parents](https://github.com/pensoft/BiCIKL/blob/main/Topic%201%20Finding%20the%20lost%20parents/lostParents.md)
+1. [Lost Parents](https://github.com/pensoft/BiCIKL/blob/main/Topic%201%20Finding%20the%20lost%20parents/readme.md)
 2. [How good are Triple IDs in ENA?]()
 3. [Enhance the GBIF clustering algorithms]()
 4. [Assigning latin scientific names to OTUs based on sequence clusters]()

--- a/readme.md
+++ b/readme.md
@@ -4,13 +4,16 @@ The BiCIKL BioHackathon will take place on September 20-24, 2021 at Meise Botani
 
 All BiCIKL partners are invited to propose topics which will then be reviewed in the week of June 28-July 2 by partners involved in Task 1.2. Please add your ideas for topics with a short description in this document by the end of this week. Please describe clearly which infrastructures would be involved and how the hackathon could contribute in making the infrastructures more interoperable. 
 
-1. [Lost Parents](https://github.com/pensoft/BiCIKL/blob/main/Topic%201%20Finding%20the%20lost%20parents/readme.md)
-2. [How good are Triple IDs in ENA?]()
-3. [Enhance the GBIF clustering algorithms]()
-4. [Assigning latin scientific names to OTUs based on sequence clusters]()
-5. [Registering biodiversity-related vocabulary as Wikidata lexemes and link their senses to Wikidata items]()
-6. [FAIR Digital Object design for data from multiple sources]()
-7. [Enriching Wikidata with information from OpenBiodiv about taxonomic name usages in context from different literature sources]()
-8. [Linking specimen with material citation and vice versa]()
-9. [Hidden women in science]()
-10. [A LifeBlock traceability and provenance service for data from external sources]()
+
+1. [Topic 1 Finding the lost parents](Topic%201%20Finding%20the%20lost%20parents/readme.md)
+1. [Topic 2 How good are Triple IDs in ENA](Topic%202%20How%20good%20are%20Triple%20IDs%20in%20ENA/readme.md)
+1. [Topic 3 Enhance the GBIF clustering algorithms](Topic%203%20Enhance%20the%20GBIF%20clustering%20algorithms/readme.md)
+1. [Topic 4 Assigning latin scientific names to OTUs based on sequence clusters](Topic%204%20Assigning%20latin%20scientific%20names%20to%20OTUs%20based%20on%20sequence%20clusters/readme.md)
+1. [Topic 5 Registering biodiversity-related vocabulary as Wikidata lexemes and link their senses to Wikidata items](Topic%205%20Registering%20biodiversity-related%20vocabulary%20as%20Wikidata%20lexemes%20and%20link%20their%20senses%20to%20Wikidata%20items/readme.md)
+1. [Topic 6 FAIR Digital Object design from multiple sources](Topic%206%20FAIR%20Digital%20Object%20design%20from%20multiple%20sources/readme.md)
+1. [Topic 7 Enriching Wikidata with information from OpenBiodiv about taxonomic name usages in context from different literature sources](Topic%207%20Enriching%20Wikidata%20with%20information%20from%20OpenBiodiv%20about%20taxonomic%20name%20usages%20in%20context%20from%20different%20literature%20sources/readme.md)
+1. [Topic 8 Linking specimen with material citation and vice versa](Topic%208%20Linking%20specimen%20with%20material%20citation%20and%20vice%20versa/readme.md)
+1. [Topic 9 Hidden women in science](Topic%209%20Hidden%20women%20in%20science/readme.md)
+1. [Topic 10 An IPFS-Blockchain Interface](Topic%2010%20An%20IPFS-Blockchain%20Interface/readme.md)
+
+

--- a/readme.md
+++ b/readme.md
@@ -5,15 +5,15 @@ The BiCIKL BioHackathon will take place on September 20-24, 2021 at Meise Botani
 All BiCIKL partners are invited to propose topics which will then be reviewed in the week of June 28-July 2 by partners involved in Task 1.2. Please add your ideas for topics with a short description in this document by the end of this week. Please describe clearly which infrastructures would be involved and how the hackathon could contribute in making the infrastructures more interoperable. 
 
 
-1. [Topic 1 Finding the lost parents](Topic%201%20Finding%20the%20lost%20parents/readme.md)
-1. [Topic 2 How good are Triple IDs in ENA](Topic%202%20How%20good%20are%20Triple%20IDs%20in%20ENA/readme.md)
-1. [Topic 3 Enhance the GBIF clustering algorithms](Topic%203%20Enhance%20the%20GBIF%20clustering%20algorithms/readme.md)
-1. [Topic 4 Assigning latin scientific names to OTUs based on sequence clusters](Topic%204%20Assigning%20latin%20scientific%20names%20to%20OTUs%20based%20on%20sequence%20clusters/readme.md)
-1. [Topic 5 Registering biodiversity-related vocabulary as Wikidata lexemes and link their senses to Wikidata items](Topic%205%20Registering%20biodiversity-related%20vocabulary%20as%20Wikidata%20lexemes%20and%20link%20their%20senses%20to%20Wikidata%20items/readme.md)
-1. [Topic 6 FAIR Digital Object design from multiple sources](Topic%206%20FAIR%20Digital%20Object%20design%20from%20multiple%20sources/readme.md)
-1. [Topic 7 Enriching Wikidata with information from OpenBiodiv about taxonomic name usages in context from different literature sources](Topic%207%20Enriching%20Wikidata%20with%20information%20from%20OpenBiodiv%20about%20taxonomic%20name%20usages%20in%20context%20from%20different%20literature%20sources/readme.md)
-1. [Topic 8 Linking specimen with material citation and vice versa](Topic%208%20Linking%20specimen%20with%20material%20citation%20and%20vice%20versa/readme.md)
-1. [Topic 9 Hidden women in science](Topic%209%20Hidden%20women%20in%20science/readme.md)
-1. [Topic 10 An IPFS-Blockchain Interface](Topic%2010%20An%20IPFS-Blockchain%20Interface/readme.md)
+1. [Finding the lost parents](Topic%201%20Finding%20the%20lost%20parents/readme.md)
+2. [How good are Triple IDs in ENA](Topic%202%20How%20good%20are%20Triple%20IDs%20in%20ENA/readme.md)
+3. [Enhance the GBIF clustering algorithms](Topic%203%20Enhance%20the%20GBIF%20clustering%20algorithms/readme.md)
+4. [Assigning latin scientific names to OTUs based on sequence clusters](Topic%204%20Assigning%20latin%20scientific%20names%20to%20OTUs%20based%20on%20sequence%20clusters/readme.md)
+5. [Registering biodiversity-related vocabulary as Wikidata lexemes and link their senses to Wikidata items](Topic%205%20Registering%20biodiversity-related%20vocabulary%20as%20Wikidata%20lexemes%20and%20link%20their%20senses%20to%20Wikidata%20items/readme.md)
+6. [FAIR Digital Object design from multiple sources](Topic%206%20FAIR%20Digital%20Object%20design%20from%20multiple%20sources/readme.md)
+7. [Enriching Wikidata with information from OpenBiodiv about taxonomic name usages in context from different literature sources](Topic%207%20Enriching%20Wikidata%20with%20information%20from%20OpenBiodiv%20about%20taxonomic%20name%20usages%20in%20context%20from%20different%20literature%20sources/readme.md)
+8. [Linking specimen with material citation and vice versa](Topic%208%20Linking%20specimen%20with%20material%20citation%20and%20vice%20versa/readme.md)
+9. [Hidden women in science](Topic%209%20Hidden%20women%20in%20science/readme.md)
+10. [An IPFS-Blockchain Interface](Topic%2010%20An%20IPFS-Blockchain%20Interface/readme.md)
 
 


### PR DESCRIPTION
- Migrating the topic descriptions from the google doc to github markdown. 
- Adding topic overview table to repo readme. 
- Adding relative links to topic descriptions to repo readme. 